### PR TITLE
Always remove identifier object on Dumpster.Remove

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -418,13 +418,14 @@ function Dumpster:Remove(cleanObject: any, dontCallCleanMethod: boolean?): any?
 
 		local object = self._identifierObjects[cleanObject].object
 		local method = self._identifierObjects[cleanObject].method
+		
+		self._identifierObjects[cleanObject] = nil
 
 		if dontCallCleanMethod then
-			self._identifierObjects[cleanObject] = nil
 			return object
-		else
-			self:_cleanObject(object, method, true)
 		end
+
+		self:_cleanObject(object, method, true)
 
 		return
 	end


### PR DESCRIPTION
**Previous behavior:**
Only removes identifier object when Dumpster is cleaned/destroyed OR when the Remove method is passed the "dontCallCleanMethod" variable as true. So when "dontCallCleanMethod" is false/nil it will not remove the identifier object. It will only run the invoke the clean method. This results in an error of: "A cleanup identifier with ID: " .. cleanupIdentifier .. "already exists" when trying to add the same identifier after invoking the Remove method before cleaning/destroying the Dumpster.

**Expected behavior:**
Always remove identifier object when invoking a Dumpster's Remove method, regardless of the "dontCallCleanMethod" value so it can be reused without destroying/cleaning the entire Dumpster.